### PR TITLE
HK10, HK11 - Disable some commands and flight based on coords

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>me.drendov.HouseKeeping</groupId>
     <artifactId>HouseKeeping</artifactId>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
     <packaging>jar</packaging>
     <name>HouseKeeping</name>
     <description>A plugin to keep our minecraft server clean and safe.</description>

--- a/src/main/java/me/drendov/HouseKeeping/Config.java
+++ b/src/main/java/me/drendov/HouseKeeping/Config.java
@@ -1,11 +1,19 @@
 package me.drendov.HouseKeeping;
 
+import org.bukkit.Location;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 
 class Config {
     private HouseKeeping plugin;
     private FileConfiguration config;
     private static Integer daysWithholdFunds;
+    public static List<String> safezoneBlockedCommands = new ArrayList<String>();
 
     Config(HouseKeeping plugin) {
         this.plugin = plugin;
@@ -16,13 +24,31 @@ class Config {
         this.config = this.plugin.getConfig();
         this.config.addDefault("debug", "true");
         this.config.addDefault("daysWithholdFunds", 30);
+        this.config.addDefault("safezone", "true");
+        this.config.addDefault("safezone.x1", -100);
+        this.config.addDefault("safezone.y1", -100);
+        this.config.addDefault("safezone.x2", 100);
+        this.config.addDefault("safezone.y2", 100);
+        List<String> blockedCommands = Arrays.asList("sethome", "home", "ehome", "homes", "ehomes", "tpa", "tphere", "tpyes", "call", "ecall", "etpa", "tpask", "etpask", "spawn", "warp", "warps", "ewarp", "warps", "ewarps");
+        this.config.addDefault("blockedCommands", blockedCommands);
         this.config.options().copyDefaults(true);
         this.plugin.saveConfig();
         daysWithholdFunds = this.config.getInt("daysWithholdFunds");
+        safezoneBlockedCommands = this.config.getStringList("blockedCommands");
     }
 
     public int getDaysWithholdFunds() {
         return daysWithholdFunds;
     }
-}
 
+    public List<String> getSafezoneBlockedCommands() {
+        return safezoneBlockedCommands;
+    }
+
+    public HashMap<String, Location> getSafeZoneArea(Player player) {
+        HashMap<String, Location> safeZoneArea = new HashMap<>();
+        safeZoneArea.put("loc1", new Location(player.getWorld(), this.config.getDouble("safezone.x1"), 0.0, this.config.getDouble("safezone.y1" )));
+        safeZoneArea.put("loc2", new Location(player.getWorld(), this.config.getDouble("safezone.x2"), 255.0, this.config.getDouble("safezone.y2")));
+        return safeZoneArea;
+    }
+}

--- a/src/main/java/me/drendov/HouseKeeping/Config.java
+++ b/src/main/java/me/drendov/HouseKeeping/Config.java
@@ -14,6 +14,7 @@ class Config {
     private FileConfiguration config;
     private static Integer daysWithholdFunds;
     public static List<String> safezoneBlockedCommands = new ArrayList<String>();
+    private static String safezoneWorld;
 
     Config(HouseKeeping plugin) {
         this.plugin = plugin;
@@ -25,6 +26,7 @@ class Config {
         this.config.addDefault("debug", "true");
         this.config.addDefault("daysWithholdFunds", 30);
         this.config.addDefault("safezone", "true");
+        this.config.addDefault("safezone.world", "survival");
         this.config.addDefault("safezone.x1", -100);
         this.config.addDefault("safezone.y1", -100);
         this.config.addDefault("safezone.x2", 100);
@@ -34,11 +36,17 @@ class Config {
         this.config.options().copyDefaults(true);
         this.plugin.saveConfig();
         daysWithholdFunds = this.config.getInt("daysWithholdFunds");
+        safezoneWorld = this.config.getString("safezone.world");
         safezoneBlockedCommands = this.config.getStringList("blockedCommands");
+
     }
 
     public int getDaysWithholdFunds() {
         return daysWithholdFunds;
+    }
+
+    public String getSafezoneWorld() {
+        return safezoneWorld;
     }
 
     public List<String> getSafezoneBlockedCommands() {

--- a/src/main/java/me/drendov/HouseKeeping/HouseKeeping.java
+++ b/src/main/java/me/drendov/HouseKeeping/HouseKeeping.java
@@ -135,7 +135,7 @@ public class HouseKeeping extends JavaPlugin {
         this.addDefault(defaults, Messages.ReloadMsg, "Reload the plugin config from the disc.", null);
         this.addDefault(defaults, Messages.NoPermissionForCommand, "You don't have permission to do that.", null);
         this.addDefault(defaults, Messages.DenyCommandMsg, "You are not allowed to run such command here.", null);
-
+        this.addDefault(defaults, Messages.CantFlyHere, "You can't fly here.", null);
 
         // load the config file
         FileConfiguration config = YamlConfiguration.loadConfiguration(new File(messagesFilePath));

--- a/src/main/java/me/drendov/HouseKeeping/HouseKeeping.java
+++ b/src/main/java/me/drendov/HouseKeeping/HouseKeeping.java
@@ -134,6 +134,8 @@ public class HouseKeeping extends JavaPlugin {
         this.addDefault(defaults, Messages.Reloaded, "Config reloaded.", null);
         this.addDefault(defaults, Messages.ReloadMsg, "Reload the plugin config from the disc.", null);
         this.addDefault(defaults, Messages.NoPermissionForCommand, "You don't have permission to do that.", null);
+        this.addDefault(defaults, Messages.DenyCommandMsg, "You are not allowed to run such command here.", null);
+
 
         // load the config file
         FileConfiguration config = YamlConfiguration.loadConfiguration(new File(messagesFilePath));

--- a/src/main/java/me/drendov/HouseKeeping/Listeners.java
+++ b/src/main/java/me/drendov/HouseKeeping/Listeners.java
@@ -1,10 +1,14 @@
 package me.drendov.HouseKeeping;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.logging.Logger;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.inventory.InventoryOpenEvent;
-
-import java.util.logging.Logger;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 
 public class Listeners
         implements Listener {
@@ -12,11 +16,49 @@ public class Listeners
     private static Logger logger = plugin.getLogger();
 
     @EventHandler
-    public void inventoryOpenListener(InventoryOpenEvent event) {
-        String player = event.getPlayer().getName();
+    public void onPlayerCommandPreProcess(final PlayerCommandPreprocessEvent event) {
 
-        HouseKeeping.sendMessage(null, TextMode.Instr,
-                "User " + event.getPlayer().getName());
+        Player player = null;
+        if (event.getPlayer() instanceof Player) {
+            player = event.getPlayer();
+        }
+
+        if (player.isOp() || player.hasPermission("housekeeping.bypass"))
+            return;
+
+        GameMode mode = player.getGameMode();
+        if (mode != GameMode.CREATIVE && mode != GameMode.SPECTATOR) {
+            HashMap getSafeZoneArea = HouseKeeping.getInstance().config.getSafeZoneArea(player);
+            Location loc1 = (Location) getSafeZoneArea.get("loc1");
+            Location loc2 = (Location) getSafeZoneArea.get("loc2");
+            if (this.isInRect(player, loc1, loc2)) {
+                for (final String command : HouseKeeping.getInstance().config.getSafezoneBlockedCommands()) {
+                    if (event.getMessage().toLowerCase().equals("/" + command) || event.getMessage().toLowerCase().startsWith("/" + command + " ")) {
+                        event.setCancelled(true);
+                        HouseKeeping.sendMessage(player, TextMode.Err, Messages.DenyCommandMsg);
+                    }
+                }
+            }
+        }
+
+    }
+
+    public boolean isInRect(Player player, Location loc1, Location loc2) {
+        double[] dim = new double[2];
+
+        dim[0] = loc1.getX();
+        dim[1] = loc2.getX();
+        Arrays.sort(dim);
+        if (player.getLocation().getX() > dim[1] || player.getLocation().getX() < dim[0])
+            return false;
+
+        dim[0] = loc1.getZ();
+        dim[1] = loc2.getZ();
+        Arrays.sort(dim);
+        if (player.getLocation().getZ() > dim[1] || player.getLocation().getZ() < dim[0])
+            return false;
+
+        return true;
     }
 }
 

--- a/src/main/java/me/drendov/HouseKeeping/Listeners.java
+++ b/src/main/java/me/drendov/HouseKeeping/Listeners.java
@@ -23,6 +23,9 @@ public class Listeners
             player = event.getPlayer();
         }
 
+        if (!player.getWorld().getName().equals(HouseKeeping.getInstance().config.getSafezoneWorld()))
+            return;
+
         if (player.isOp() || player.hasPermission("housekeeping.bypass"))
             return;
 

--- a/src/main/java/me/drendov/HouseKeeping/Listeners.java
+++ b/src/main/java/me/drendov/HouseKeeping/Listeners.java
@@ -9,6 +9,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerToggleFlightEvent;
 
 public class Listeners
         implements Listener {
@@ -44,6 +46,48 @@ public class Listeners
             }
         }
 
+    }
+
+    // TODO: Check performance via load testing.
+    // Refactor to use scheduler instead
+    @EventHandler
+    public void onMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+
+        if (!player.isFlying()) return;
+        if (!player.getWorld().getName().equals(HouseKeeping.getInstance().config.getSafezoneWorld())) return;
+        if (player.isOp() || player.hasPermission("housekeeping.bypass") || player.hasPermission("housekeeping.bypass.fly")) return;
+
+        GameMode mode = player.getGameMode();
+        if (mode != GameMode.CREATIVE && mode != GameMode.SPECTATOR) {
+            HashMap getSafeZoneArea = HouseKeeping.getInstance().config.getSafeZoneArea(player);
+            Location loc1 = (Location) getSafeZoneArea.get("loc1");
+            Location loc2 = (Location) getSafeZoneArea.get("loc2");
+            if (! this.isInRect(player, loc1, loc2)) {
+                player.setFlying(false);
+                HouseKeeping.sendMessage(player, TextMode.Err, Messages.CantFlyHere);
+            }
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerToggleFlight(PlayerToggleFlightEvent event) {
+        Player player = event.getPlayer();
+        if (!player.isFlying()) return;
+        if (!player.getWorld().getName().equals(HouseKeeping.getInstance().config.getSafezoneWorld())) return;
+        if (player.isOp() || player.hasPermission("housekeeping.bypass") || player.hasPermission("housekeeping.bypass.fly")) return;
+
+        GameMode mode = player.getGameMode();
+        if (mode != GameMode.CREATIVE && mode != GameMode.SPECTATOR) {
+            HashMap getSafeZoneArea = HouseKeeping.getInstance().config.getSafeZoneArea(player);
+            Location loc1 = (Location) getSafeZoneArea.get("loc1");
+            Location loc2 = (Location) getSafeZoneArea.get("loc2");
+            if (! this.isInRect(player, loc1, loc2)) {
+                HouseKeeping.sendMessage(player, TextMode.Err, Messages.CantFlyHere);
+                event.setCancelled(true);
+                player.setAllowFlight(false);
+            }
+        }
     }
 
     public boolean isInRect(Player player, Location loc1, Location loc2) {

--- a/src/main/java/me/drendov/HouseKeeping/Listeners.java
+++ b/src/main/java/me/drendov/HouseKeeping/Listeners.java
@@ -31,7 +31,7 @@ public class Listeners
             HashMap getSafeZoneArea = HouseKeeping.getInstance().config.getSafeZoneArea(player);
             Location loc1 = (Location) getSafeZoneArea.get("loc1");
             Location loc2 = (Location) getSafeZoneArea.get("loc2");
-            if (this.isInRect(player, loc1, loc2)) {
+            if (! this.isInRect(player, loc1, loc2)) {
                 for (final String command : HouseKeeping.getInstance().config.getSafezoneBlockedCommands()) {
                     if (event.getMessage().toLowerCase().equals("/" + command) || event.getMessage().toLowerCase().startsWith("/" + command + " ")) {
                         event.setCancelled(true);

--- a/src/main/java/me/drendov/HouseKeeping/Messages.java
+++ b/src/main/java/me/drendov/HouseKeeping/Messages.java
@@ -4,5 +4,6 @@ public enum Messages
 {
     Reloaded,
     NoPermissionForCommand,
-    ReloadMsg
+    ReloadMsg,
+    DenyCommandMsg
 }

--- a/src/main/java/me/drendov/HouseKeeping/Messages.java
+++ b/src/main/java/me/drendov/HouseKeeping/Messages.java
@@ -5,5 +5,6 @@ public enum Messages
     Reloaded,
     NoPermissionForCommand,
     ReloadMsg,
-    DenyCommandMsg
+    DenyCommandMsg,
+    CantFlyHere
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,9 +2,9 @@ name: HouseKeeping
 version: ${project.version}
 description: This plugin helps us to keep our minecraft server clean and safe.
 website: https://github.com/DmitryRendov/HouseKeeping
-author: DmitryRendov
+author: [DmitryRendov, AlexeyFilich]
 main: me.drendov.HouseKeeping.HouseKeeping
-api-version: 1.17
+api-version: 1.13
 
 depend: [Vault, Essentials]
 


### PR DESCRIPTION
address #10 

Test cases:
Put into `permissions.yml` necessary permissions:
```
server.basics:
       description: Basic permissions for My Test Server.
       default: true
       children:
          essentials.spawn: true
          essentials.call: true
          essentials.home: true
          essentials.sethome: true
          essentials.tpa: true
          essentials.tpaccept: true
          essentials.tpahere: true
          essentials.warp: true
          essentials.warp.list: true
          essentials.fly: true
          essentials.fly.safelogin: true
```

Then try these commands `/tp /spawn /warp/ home /sethome /fly`
* within Safe area and
* outside the zone, specified in the config (-100,100 -- 100,100).
* should work only in survival mode and only in the Survival world

Most dangerous is No flight check - we need carefully checking if
* helpers will loose the flight and land with no harm
* helpers allowed to fly in safe zone
* all players can fly with no issues using elytra
* onMove event won't break performance (otherwise we have to rewrite using scheduled checks)